### PR TITLE
Jenkinsfile_remove_machine: update to follow ansible playbook changes

### DIFF
--- a/Jenkinsfile_remove_machine
+++ b/Jenkinsfile_remove_machine
@@ -83,7 +83,6 @@ following file:
                     sshagent(credentials : ['cluster']) {
                         sh """
                         ansible-playbook \
-                            --limit="${ansible_host}" \
                             -e machine_to_remove="${machine}" \
                             playbooks/replace_machine_remove_machine_from_cluster.yaml
                     """


### PR DESCRIPTION
There is no longer needs to limit hosts with playbooks/replace_machine_remove_machine_from_cluster.yaml.

Signed-off-by: Mathieu Dupré <mathieu.dupre@savoirfairelinux.com>